### PR TITLE
prevents adding empty string to ignored list somehow fixes #1

### DIFF
--- a/ignoreword.py
+++ b/ignoreword.py
@@ -6,7 +6,7 @@ class Ignoreword(sublime_plugin.EventListener):
       settings = sublime.load_settings('Preferences.sublime-settings')
       ignored_words = settings.get('ignored_words', [])
       word = args['word']
-      if word not in ignored_words :
+      if word and word not in ignored_words :
         ignored_words.append(word)
         settings.set('ignored_words', ignored_words)
         sublime.save_settings('Preferences.sublime-settings')


### PR DESCRIPTION
Does not entirely fix the problem since it's a sublime text bug but prevent adding an empty string to the ignored list. 
sublime does not pass single unicode character as word argument to the `on_text_event`